### PR TITLE
Add a .gitignore to ignore built files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.pyc
+*._
+*.egg-info
+__pycache__
+dist
+build


### PR DESCRIPTION
The `.gitignore` file makes compiled `.pyc` files and other build output be ignored by git.