### PR TITLE
Fix the long description to use README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ else:
 
 setup(name="PyICU",
       description='Python extension wrapping the ICU C++ API',
-      long_description=open('README').read(),
+      long_description=open('README.md').read(),
       version=VERSION,
       test_suite="test",
       url='http://pyicu.osafoundation.org/',


### PR DESCRIPTION
I was getting issues running `setup.py build` because of a reference to a missing file.