### PR TITLE
Add wrappers for NumberFormat.isLenient/setLenient

### DIFF
--- a/numberformat.cpp
+++ b/numberformat.cpp
@@ -105,6 +105,9 @@ static PyObject *t_numberformat_setMaximumFractionDigits(t_numberformat *self,
 static PyObject *t_numberformat_getMinimumFractionDigits(t_numberformat *self);
 static PyObject *t_numberformat_setMinimumFractionDigits(t_numberformat *self,
                                                         PyObject *arg);
+static PyObject *t_numberformat_isLenient(t_numberformat *self);
+static PyObject *t_numberformat_setLenient(t_numberformat *self,
+                                           PyObject *arg);
 static PyObject *t_numberformat_getCurrency(t_numberformat *self);
 static PyObject *t_numberformat_setCurrency(t_numberformat *self,
                                             PyObject *arg);
@@ -134,6 +137,8 @@ static PyMethodDef t_numberformat_methods[] = {
     DECLARE_METHOD(t_numberformat, setMaximumFractionDigits, METH_O),
     DECLARE_METHOD(t_numberformat, getMinimumFractionDigits, METH_NOARGS),
     DECLARE_METHOD(t_numberformat, setMinimumFractionDigits, METH_O),
+    DECLARE_METHOD(t_numberformat, isLenient, METH_NOARGS),
+    DECLARE_METHOD(t_numberformat, setLenient, METH_O),
     DECLARE_METHOD(t_numberformat, getCurrency, METH_NOARGS),
     DECLARE_METHOD(t_numberformat, setCurrency, METH_O),
     DECLARE_METHOD(t_numberformat, createInstance, METH_VARARGS | METH_CLASS),
@@ -900,6 +905,26 @@ static PyObject *t_numberformat_setMinimumFractionDigits(t_numberformat *self,
     }
 
     return PyErr_SetArgsError((PyObject *) self, "setMinimumFractionDigits", arg);
+}
+
+static PyObject *t_numberformat_isLenient(t_numberformat *self)
+{
+    UBool n = self->object->isLenient();
+    Py_RETURN_BOOL(n);
+}
+
+static PyObject *t_numberformat_setLenient(t_numberformat *self,
+                                           PyObject *arg)
+{
+    int b;
+
+    if (!parseArg(arg, "b", &b))
+    {
+        self->object->setLenient(b);
+        Py_RETURN_NONE;
+    }
+
+    return PyErr_SetArgsError((PyObject *) self, "setLenient", arg);
 }
 
 static PyObject *t_numberformat_getCurrency(t_numberformat *self)


### PR DESCRIPTION
This adds support for setting the `lenient` property on `NumberFormat` instances.