### PR TITLE
Don't apply compatibility hack when PyPy (5.2) already is compatible.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -19,6 +19,7 @@ below.
   - Fredrik Roubert for various bug fixes (see CHANGES)
   - Markus Scherer for various bug fixes (see CHANGES)
   - Martin Hosken for bug fixes (see CHANGES)
+  - Google Inc. for bug fixes.
   - 
 
 Thank you all !

--- a/tzinfo.cpp
+++ b/tzinfo.cpp
@@ -30,7 +30,7 @@
 #include "tzinfo.h"
 #include "macros.h"
 
-#ifdef PYPY_VERSION
+#if defined(PYPY_VERSION_NUM) && PYPY_VERSION_NUM < 0x05020000
 typedef PyObject PyDateTime_TZInfo;
 #endif
 


### PR DESCRIPTION
Better datetime support is coming in 5.2, this workaround breaks compilation.  Woohoo!

Sorry about the CREDITS edit, not sure where to put it. It's my employer's policy to try to keep copyright info up to date.