### PR TITLE
add setTimeZone in testGetBestPattern (fixes #19)

### DIFF
--- a/test/test_DateTimeParserGenerator.py
+++ b/test/test_DateTimeParserGenerator.py
@@ -71,6 +71,7 @@ class TestDateTimePatternGenerator(TestCase):
             for index, skeleton in enumerate(skeletons):
                 pattern = dtpg.getBestPattern(skeleton)
                 sdf = SimpleDateFormat(pattern, locale)
+                sdf.setTimeZone(self.tz)
                 self.assertEqual(sdf.format(self.date), locale_data[index])
 
     def testReplaceFieldType(self):


### PR DESCRIPTION
The same approach was used in other test cases except for this one, and adding it here fixes the test failure in #19 for me.