### PR TITLE
support non-Linux systems with GNU userland

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ LIBRARIES = {
 }
 
 platform = sys.platform
-if platform.startswith('linux'):
+if platform.startswith(('linux', 'gnu')):
     platform = 'linux'
 elif platform.startswith('freebsd'):
     platform = 'freebsd'


### PR DESCRIPTION
Treat systems with GNU userland the same way as Linux.

This fixes build failures at least on:
- GNU/kFreeBSD (`sys.platform == "gnukfreebsd10"` or similar)
- GNU/Hurd (`sys.platform == "gnu0"`)