### PR TITLE
Continuous integration with Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 dist
 build
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: python
+sudo: false
+dist: trusty
+
+notifications:
+  email: false
+
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+env:
+  global:
+    - ICU_VERSION="59.1"
+    - PYICU_LIBRARIES="icui18n:icuuc:icudata"
+    - PYICU_INCLUDES="/tmp/icu4c/include"
+    - PYICU_LFLAGS="-L/tmp/icu4c/lib"
+
+cache:
+  ccache: true
+  pip: true
+  timeout: 1000
+  directories:
+    - /tmp/icu4c
+
+before_install:
+  # install ICU4C from source
+  - mkdir -p /tmp/icu4c
+  - export ICU_URL="https://downloads.sourceforge.net/project/icu/ICU4C/$ICU_VERSION/icu4c-${ICU_VERSION/./_}-src.tgz"
+  - wget -nv -O /tmp/icu4c/icu4c.tgz "$ICU_URL"
+  - tar -xzf /tmp/icu4c/icu4c.tgz -C /tmp/icu4c
+  - pushd /tmp/icu4c/icu/source && ./configure --prefix=/tmp/icu4c && make && make install && popd
+
+install:
+  - pip install . pytest six
+
+script:
+  - LD_LIBRARY_PATH="/tmp/icu4c/lib" py.test

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,11 @@ INCLUDES = {
 }
 
 CFLAGS = {
-    'darwin': ['-DPYICU_VER="%s"' %(VERSION)],
-    'linux': ['-DPYICU_VER="%s"' %(VERSION)],
-    'freebsd': ['-DPYICU_VER="%s"' %(VERSION)],
+    'darwin': ['-DPYICU_VER="%s"' %(VERSION), '-std=c++11'],
+    'linux': ['-DPYICU_VER="%s"' %(VERSION), '-std=c++11'],
+    'freebsd': ['-DPYICU_VER="%s"' %(VERSION), '-std=c++11'],
     'win32': ['/Zc:wchar_t', '/EHsc', '/DPYICU_VER=\\"%s\\"' %(VERSION)],
-    'sunos5': ['-DPYICU_VER="%s"' %(VERSION)],
+    'sunos5': ['-DPYICU_VER="%s"' %(VERSION), '-std=c++11'],
 }
 
 # added to CFLAGS when setup is invoked with --debug
@@ -147,14 +147,5 @@ setup(name="PyICU",
                              extra_link_args=_lflags,
                              libraries=_libraries)],
       packages=['icu'],
-      py_modules=['PyICU'])
-
-
-if sys.version_info >= (3,):
-    path = os.path.join('test', '2to3.note')
-    if not os.path.exists(path):
-        from lib2to3.main import main
-        main("lib2to3.fixes", ['-w', '-n', '--no-diffs', 'test'])
-        output = open(path, 'w')
-        output.write('tests auto-converted by 2to3 during setup\n')
-        output.close()
+      py_modules=['PyICU'],
+      tests_require=['pytest', 'six'])

--- a/test/test_Charset.py
+++ b/test/test_Charset.py
@@ -6,10 +6,10 @@
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions: 
+# Software is furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software. 
+# in all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -21,7 +21,7 @@
 # ====================================================================
 #
 
-import sys, os
+import sys, os, six
 
 from unittest import TestCase, main
 from icu import *
@@ -59,11 +59,11 @@ class TestCharset(TestCase):
     def testUnicode(self):
 
         bytes = u'beaut\xe9 probable'.encode('iso-8859-1')
-        ustring = unicode(CharsetDetector(bytes).detect())
+        ustring = six.text_type(CharsetDetector(bytes).detect())
 
         self.assertTrue(ustring.encode('iso-8859-1') == bytes)
-        
-        
+
+
 
 if __name__ == "__main__":
     main()

--- a/test/test_Collator.py
+++ b/test/test_Collator.py
@@ -6,10 +6,10 @@
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions: 
+# Software is furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software. 
+# in all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -21,7 +21,7 @@
 # ====================================================================
 #
 
-import sys, os
+import sys, os, six
 
 from unittest import TestCase, main
 from icu import *
@@ -44,7 +44,7 @@ class TestCollator(TestCase):
 
         collator = Collator.createInstance(Locale.getFrance())
         input = open(self.filePath('noms.txt'), 'rb')
-        names = [unicode(n.strip(), 'utf-8') for n in input.readlines()]
+        names = [six.text_type(n.strip(), 'utf-8') for n in input.readlines()]
         input.close()
         ecole = names[0]
 

--- a/test/test_LayoutEngine.py
+++ b/test/test_LayoutEngine.py
@@ -7,10 +7,10 @@
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions: 
+# Software is furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software. 
+# in all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -22,7 +22,7 @@
 # ====================================================================
 #
 
-import sys, os
+import sys, os, six
 
 from unittest import TestCase, main
 from icu import *
@@ -31,10 +31,10 @@ try:
     if ICU_VERSION >= '58':
         raise NotImplementedError
     from fontTools.ttLib import TTFont
-except ImportError, e:
-    print >>sys.stderr, "\nfontTools package not found, skipping LayoutEngine tests\n"
+except ImportError as e:
+    sys.stderr.write("\nfontTools package not found, skipping LayoutEngine tests\n")
 except NotImplementedError:
-    print >>sys.stderr, "\nLayoutEngine not available in ICU %s" %(ICU_VERSION)
+    sys.stderr.write("\nLayoutEngine not available in ICU %s" %(ICU_VERSION))
 else:
     class TTXLEFont(LEFontInstance):
 

--- a/test/test_LocaleData.py
+++ b/test/test_LocaleData.py
@@ -6,10 +6,10 @@
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions: 
+# Software is furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software. 
+# in all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -22,7 +22,7 @@
 #
 # This is a python translation of ICU's LocaleDataTest.java
 
-import sys, os
+import sys, os, six
 
 from unittest import TestCase, main
 from icu import *
@@ -54,7 +54,7 @@ class TestLocaleData(TestCase):
             papersize = LocaleData(locale).getPaperSize()
             #language = Locale(locale).getLanguage()
             country = Locale(locale).getCountry()
-            
+
             if (['BZ','CA','CL','CO','CR','GT','MX','NI','PA','PH','PR','SV','US','VE'].count(country) > 0):
                 self.assertTrue(papersize == (279, 216))
             elif country:
@@ -65,19 +65,19 @@ class TestLocaleData(TestCase):
             measurementSystem = LocaleData(locale).getMeasurementSystem()
             #language = Locale(locale).getLanguage()
             country = Locale(locale).getCountry()
-            
+
             # 0 means SI, 1 means US, 2 mean UK
             if (country in ['LR', 'MM', 'US']):
                 self.assertTrue(measurementSystem == 1)
-            elif country in ['GB']: 
+            elif country in ['GB']:
                 self.assertTrue(measurementSystem in [0, 2])
-            elif country: 
+            elif country:
                 self.assertTrue(measurementSystem == 0)
-            
+
     def testExemplarSet(self):
         testedExemplars = set()
         equalCount = 0
-        
+
         for locale in self.availableLocales:
             scriptCodes = Script.getCode(locale)
             exemplarSets = []
@@ -108,18 +108,18 @@ class TestLocaleData(TestCase):
                                     break
                     if existsInScript == False:
                         print_output("ExemplarSet containment failed for locale : "+ locale)
-            print_output(locale + " exemplar " + repr(unicode(exemplarSets[0])))
-            print_output(locale + " exemplar(case-folded) " + repr(unicode(exemplarSets[1])))
+            print_output(locale + " exemplar " + repr(six.text_type(exemplarSets[0])))
+            print_output(locale + " exemplar(case-folded) " + repr(six.text_type(exemplarSets[1])))
             self.assertTrue(locale + " case-folded is a superset", exemplarSets[1].containsAll(exemplarSets[0]))
             if (exemplarSets[1] == exemplarSets[0]):
                 ++equalCount
         self.assertTrue("case-folded is sometimes a strict superset, and sometimes equal",\
                         equalCount > 0 and equalCount < len(self.availableLocales))
-    
+
     def testExemplarSet2(self):
         testedExemplars = set()
         equalCount = 0
-        
+
         for locale in self.availableLocales:
             ld = LocaleData(locale)
             scriptCodes = Script.getCode(locale)
@@ -154,10 +154,10 @@ class TestLocaleData(TestCase):
                             if existsInScript == False and h == 0:
                                 print_output("ExemplarSet containment failed for locale,option,type : " \
                                       + locale + "," + str(option) + "," + str(esType))
-            print_output(locale + " exemplar(ES_STANDARD)" + repr(unicode(exemplarSets[0])))
-            print_output(locale + " exemplar(ES_AUXILIARY)" + repr(unicode(exemplarSets[1])))
-            print_output(locale + " exemplar(case-folded,ES_STANDARD)" + repr(unicode(exemplarSets[2])))
-            print_output(locale + " exemplar(case-folded,ES_AUXILIARY)" + repr(unicode(exemplarSets[3])))
+            print_output(locale + " exemplar(ES_STANDARD)" + repr(six.text_type(exemplarSets[0])))
+            print_output(locale + " exemplar(ES_AUXILIARY)" + repr(six.text_type(exemplarSets[1])))
+            print_output(locale + " exemplar(case-folded,ES_STANDARD)" + repr(six.text_type(exemplarSets[2])))
+            print_output(locale + " exemplar(case-folded,ES_AUXILIARY)" + repr(six.text_type(exemplarSets[3])))
             self.assertTrue(locale + " case-folded is a superset", exemplarSets[2].containsAll(exemplarSets[0]))
             self.assertTrue(locale + " case-folder is a superset", exemplarSets[3].containsAll(exemplarSets[1]))
             if (exemplarSets[2] == exemplarSets[0]):
@@ -174,7 +174,7 @@ class TestLocaleData(TestCase):
         self.assertEqual(t, ld.getNoSubstitute())
         for i in range(4):
             print_output(repr(ld.getDelimiter(i)))
-    
+
     def testLocaleDisplayPattern(self):
         ld = LocaleData(Locale().getName())
         print_output("Default locale LocaleDisplayPattern:" + ld.getLocaleDisplayPattern());
@@ -184,7 +184,7 @@ class TestLocaleData(TestCase):
             try:
                 print_output(locale + " LocaleDisplayPattern:" + repr(ld.getLocaleDisplayPattern()))
                 getLocaleDisplayPattern = True
-            except ICUError, e:  # resource not found
+            except ICUError as e:  # resource not found
                 getLocaleDisplayPattern = str(e) == NOT_FOUND_ERR
             except:
                 getLocaleDisplayPattern = False
@@ -192,12 +192,12 @@ class TestLocaleData(TestCase):
             try:
                 print_output(locale + " LocaleSeparator:" + repr(ld.getLocaleSeparator()))
                 getLocaleSeparator = True
-            except ICUError, e:  # resource not found
+            except ICUError as e:  # resource not found
                 getLocaleSeparator = str(e) == NOT_FOUND_ERR
             except:
                 getLocaleSeparator = False
             self.assertTrue(getLocaleSeparator)
-        
-    
+
+
 if __name__ == "__main__":
     main()

--- a/test/test_Script.py
+++ b/test/test_Script.py
@@ -21,7 +21,7 @@
 # ====================================================================
 #
 
-import sys, os
+import sys, os, six
 
 from unittest import TestCase, main
 from icu import *
@@ -50,7 +50,7 @@ class TestScript(TestCase):
             self.assertEqual(['Latn', 'Deva', 'Hani', 'Zzzz', 'Zzzz'], names)
 
         names = [Script.getScript(pairs.char32At(i)).getShortName()
-                 for i in xrange(pairs.countChar32())]
+                 for i in range(pairs.countChar32())]
         self.assertEqual(['Latn', 'Deva', 'Hani', 'Hani'], names)
 
         iterator = StringCharacterIterator(pairs)
@@ -70,10 +70,10 @@ class TestScript(TestCase):
             self.assertEqual(str(u), char)
         elif is_unicode_32bit():
             self.assertEqual(len(char), 1)
-            self.assertEqual(unicode(u), char)
+            self.assertEqual(six.text_type(u), char)
         else:
             self.assertEqual(len(char), 2)
-            self.assertEqual(unicode(u), char)
+            self.assertEqual(six.text_type(u), char)
 
 if __name__ == "__main__":
     main()

--- a/test/test_Transliterator.py
+++ b/test/test_Transliterator.py
@@ -7,10 +7,10 @@
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions: 
+# Software is furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software. 
+# in all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -22,7 +22,7 @@
 # ====================================================================
 #
 
-import sys, os
+import sys, os, six
 
 from unittest import TestCase, main
 from icu import *
@@ -50,7 +50,7 @@ class TestTransliterator(TestCase):
         string = UnicodeString("Shang4hai3 zi4lai2shui3 lai2 zi4 hai3 shang4")
         result = u'Sh\xe0ngh\u01cei z\xecl\xe1ishu\u01d0 l\xe1i z\xec h\u01cei sh\xe0ng'
 
-        self.assertTrue(trans.transliterate(unicode(string)) == result)
+        self.assertTrue(trans.transliterate(six.text_type(string)) == result)
         self.assertTrue(trans.transliterate(string) == result)
         self.assertTrue(string == result)
 
@@ -61,7 +61,7 @@ class TestTransliterator(TestCase):
                 super(vowelSubst, _self).__init__("vowel")
                 _self.char = char
             def handleTransliterate(_self, text, pos, incremental):
-                for i in xrange(pos.start, pos.limit):
+                for i in range(pos.start, pos.limit):
                     if text[i] in u"aeiouüöä":
                         text[i] = _self.char
                 pos.start = pos.limit
@@ -72,7 +72,7 @@ class TestTransliterator(TestCase):
         string = u"Drei Chinesen mit dem Kontrabass"
         result = u'Drii Chinisin mit dim Kintribiss'
         self.assertTrue(trans.transliterate(string) == result)
- 
+
         # test registration
         Transliterator.registerInstance(trans)
 
@@ -90,7 +90,7 @@ class TestTransliterator(TestCase):
 
         trans = faultySubst()
         self.assertRaises(ValueError, trans.transliterate, "whatever")
-        
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
@ovalhub this PR adds a [Travis CI](https://travis-ci.org/) configuration file that automatically builds and runs unit tests for branches and PRs across various Python versions and architectures (currently only Linux). This is a nice sanity check that can give you some confidence that tests are passing when merging PRs.

This PR also builds [manylinux1](https://github.com/pypa/manylinux#manylinux)-compatible (aka [PEP-513](https://www.python.org/dev/peps/pep-0513/)-compliant) wheels using the Docker image provided by that project, and uploads them to GitHub Releases for any git tags. As you noted in #39, PyICU is a C extension that can be built with any combination of ICU version, OS, architecture, and Python version, so cannot support so-called universal wheels. Wheels have a number of benefits that I won't get into here, however they lack the ability to declare platform tags. This has led to problems with our internal [devpi](http://doc.devpi.net/latest/) mirror, where a wheel built on one distro and linked to a specific version of `libicu*.so.<ver>` is cached and cannot be used on platforms with a different ICU version.

Short of re-writing PyICU using cffi/ctypes, PEP-513 provides a solution to this problem, [achieving broad portability by restricting which external shared libraries the wheel is allowed to link to](https://www.python.org/dev/peps/pep-0513/#the-manylinux1-policy). This is done by bundling any external shared libraries and modifying `RPATH` (similar to static linking), which is handled automatically by the [auditwheel](https://github.com/pypa/auditwheel) tool.

This approach comes with its own benefits and drawbacks, which are [outlined in more detail in the PEP](https://www.python.org/dev/peps/pep-0513/#bundled-wheels-on-linux). In particular, PyICU releases would be tied to a specific version of ICU, rather than using the system-provided one. The situation would be much simpler if distros provided [ABI-compatible versions of ICU with function renaming disabled](http://userguide.icu-project.org/design#TOC-ICU-Binary-Compatibility:-Using-ICU-as-an-Operating-System-Level-Library), which [for various reasons](https://bugs.launchpad.net/ubuntu/+source/icu/+bug/675946) is not the case.

However, this opens up the possibility of synchronizing PyICU version numbers with upstream (e.g. pyicu==58.2 for ICU 58.2) and more easily publishing Windows and OSX packages that can be installed and used without a compiler.

You can see the [Travis builds](https://travis-ci.org/sciyoshi/pyicu/builds/221577736) and [the resulting wheels uploaded to GitHub](https://github.com/sciyoshi/pyicu/releases/tag/1.9.7.dev1) if you'd like to try using them locally.

Note that this patch also changes the tests to use [six](https://pythonhosted.org/six/) rather than [2to3](https://docs.python.org/2/library/2to3.html) as a compatibility layer, which means that the _tests_ will now only work on Python 2.6+ and Python 3.3+. Python 2.5 and below are not supported by Travis in any case, but this change is separate and could be reworked. (My editor also trimmed trailing spaces, but `?w=1` in the URL can hide that noise...)

In any case, let me know your thoughts. Thanks!