### PR TITLE
Fix str exception on setup.py for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,8 +104,7 @@ else:
 
 if 'PYICU_LIBRARIES' in os.environ:
     _libraries = os.environ['PYICU_LIBRARIES'].split(os.pathsep)
-elif ((sys.version_info >= (3,) and str(ICU_VERSION, 'ascii') < '58') or
-      (sys.version_info < (3,) and ICU_VERSION < '58')):
+elif ICU_VERSION < '58':
     _libraries = LIBRARIES[platform][:] + ['icule']
 else:
     _libraries = LIBRARIES[platform]


### PR DESCRIPTION
In Python 3, `os.environ` values are already in `str` type. There is no need to wrap them with `str` function again.

When you do `str(s, 'ascii')` on a string it raises an exception:
```
TypeError: decoding str is not supported
```

I have removed the `str()` wrapper to fix this issue.