### PR TITLE
Include casemap.h in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,3 +24,4 @@ include spoof.h
 include transliterator.h
 include tzinfo.h
 include unicodeset.h
+include casemap.h


### PR DESCRIPTION
Fix PyICU-2.0.4.tar.gz on PyPI is missing casemap.h.