### PR TITLE
add spdx license metadata to setup py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,7 @@ setup(name="PyICU",
       url='https://github.com/ovalhub/pyicu',
       author='Andi Vajda',
       author_email='github@ovaltofu.org',
+      license='MIT',
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',


### PR DESCRIPTION
Includes license information in a machine parse-able way for the python package index.

See https://setuptools.readthedocs.io/en/latest/setuptools.html#metadata and https://spdx.org/licenses