### PR TITLE
Clone transliterator object in registerInstance()

### DIFF
--- a/transliterator.cpp
+++ b/transliterator.cpp
@@ -649,7 +649,7 @@ static PyObject *t_transliterator_registerInstance(PyTypeObject *type,
 
     if (!parseArgs(args, "P", TYPE_CLASSID(Transliterator), &transliterator))
     {
-        Transliterator::registerInstance(transliterator);
+        Transliterator::registerInstance(transliterator->clone());
         Py_RETURN_NONE;
     }
 


### PR DESCRIPTION
The underlying Transliterator::registerInstance() takes ownership of the
pointer it gets passed. This conflicts with the reference counting of
the Python wrapper. Work around this by cloning the instance object.