### PR TITLE
Fix runtime `dlopen` crash on macos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ LFLAGS = {
 }
 
 LIBRARIES = {
-    'darwin': [],
+    'darwin': ['icui18n', 'icuuc', 'icudata'],
     'linux': [],
     'freebsd': ['icui18n', 'icuuc', 'icudata'],
     'win32': ['icuin', 'icuuc', 'icudt'],


### PR DESCRIPTION
Without this change `otool -L build/lib.macosx-10.14-x86_64-3.7/_icu.cpython-37m-darwin.so` doesn't show ICU system libraries as dependencies. As a result `pyicu` crashes at runtime on `dlopen`. With this change everything works just fine.