### PR TITLE
Fix build error on Python 3.9 for Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,12 @@ VER_FLAGS = {
                '-DPYICU_ICU_MAX_VER="%s"' %(ICU_MAX_MAJOR_VERSION)],
 }
 
+if sys.version_info >= (3, 9):
+    VER_FLAGS['win32'] = [
+        '-DPYICU_VER="%s"' %(VERSION),
+        '-DPYICU_ICU_MAX_VER="%s"' %(ICU_MAX_MAJOR_VERSION)
+    ]
+
 PEDANTIC_FLAGS = {
     'darwin': ['-pedantic'],
     'linux': ['-pedantic', '-Wno-variadic-macros'],


### PR DESCRIPTION
Fixes
```
_icu.cpp(209): error C2017: illegal escape sequence
_icu.cpp(209): error C2001: newline in constant
_icu.cpp(210): error C2146: syntax error: missing ')' before identifier 'PyObject_SetAttrString'
_icu.cpp(210): error C2146: syntax error: missing ';' before identifier 'PyObject_SetAttrString'
_icu.cpp(212): error C2017: illegal escape sequence
_icu.cpp(212): error C2001: newline in constant
_icu.cpp(213): error C2146: syntax error: missing ')' before identifier 'PyObject_SetAttrString'
_icu.cpp(213): error C2146: syntax error: missing ';' before identifier 'PyObject_SetAttrString'
```